### PR TITLE
fixes Makefile and missing includes in util.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 GDB=-ggdb3
 LIBS=-lm -lsdpa -llapack -lblas -lgfortran -lquadmath -lpthread -ldmumps_seq
 STATIC=-static-libgcc -static-libstdc++
-WARNS=-Wextra -Wall -Wno-sign-compare -Wshadow -Wstrict-aliasing=1 -pedantic-errors
+WARNS=-Wextra -Wall -Wno-sign-compare -Wshadow -Wstrict-aliasing=1 -Werror -Wno-unused-result -pedantic-errors
 
 CFLAGS=-ansi -std=c++11 -fabi-version=6 $(WARNS) $(OPT) $(STATIC) $(LIBS) $(GDB) $(DEBUG) $(PROFILE)
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CPP=g++-4.8
+CPP=g++
 
 #PROFILE=-pg
 #DEBUG=-DDEBUG
@@ -9,7 +9,7 @@ endif
 GDB=-ggdb3
 LIBS=-lm -lsdpa -llapack -lblas -lgfortran -lquadmath -lpthread -ldmumps_seq
 STATIC=-static-libgcc -static-libstdc++
-WARNS=-Wextra -Wall -Wno-sign-compare -Wshadow -Wstrict-aliasing=1 -Werror -pedantic-errors
+WARNS=-Wextra -Wall -Wno-sign-compare -Wshadow -Wstrict-aliasing=1 -pedantic-errors
 
 CFLAGS=-ansi -std=c++11 -fabi-version=6 $(WARNS) $(OPT) $(STATIC) $(LIBS) $(GDB) $(DEBUG) $(PROFILE)
 

--- a/util.h
+++ b/util.h
@@ -7,6 +7,8 @@
 #include <map>
 #include <unordered_map>
 #include <vector>
+#include <random>
+#include <numeric>
 
 #include "fenwick.h"
 using namespace std;


### PR DESCRIPTION
**Commit notes**:
There were some missing  `#include` in `utils.h` and two things to modify in the `Makefile` in order to compile successfully.

**Compilation notes:**
Since mumps and sdpa are not in the standard repositories of arch-linux it is virtually impossible to install the framework with this OS. It seems that there are problems with the mumps library in the AUR repository and you also have to manually compile sdpa from scratch (it was a little tricky). 

I decided to switch to a virtual machine with a debian-based distribution (lubuntu). Here we have both mumps and sdpa in the ufficial repositories, but you also need to install gfortran and f2c which are not default packages (and are not reported in the README). 

Therefore to compile install:  `libgfortran-7-dev`, `f2c` along with `libmumps-seq-dev` and `libsdpa-dev`. It's important to install the `-dev` packages because you need the headers of the libraries, otherwise you will have compilation errors.